### PR TITLE
ビュー行列や射影行列が上書きになっていて掛け算になっていませんでした

### DIFF
--- a/PGWS4/PGWS4/main.cpp
+++ b/PGWS4/PGWS4/main.cpp
@@ -211,19 +211,19 @@ int WINAPI WinMain(HINSTANCE, HINSTANCE, LPSTR, int) {
 	//};;
 
 	//default
-	//Vertex vertices[] = {
-	//{{-1.0f, -1.0f, 0.0f},{0.0f, 1.0f}}, //左下
-	//{{-1.0f, +1.0f, 0.0f},{0.0f, 0.0f}}, //左上
-	//{{+1.0f, -1.0f, 0.0f},{1.0f, 1.0f}}, //右下
-	//{{+1.0f, +1.0f, 0.0f},{1.0f, 0.0f}}, //右上
-	//};
-
 	Vertex vertices[] = {
-{{0.0f, 100.0f, 0.0f},{0.0f, 1.0f}}, //左下
-{{0.0f, 0.0f, 0.0f},{0.0f, 0.0f}}, //左上
-{{100.0f, 100.0f, 0.0f},{1.0f, 1.0f}}, //右下
-{{100.0f, 0.0f, 0.0f},{1.0f, 0.0f}}, //右上
+	{{-1.0f, -1.0f, 0.0f},{0.0f, 1.0f}}, //左下
+	{{-1.0f, +1.0f, 0.0f},{0.0f, 0.0f}}, //左上
+	{{+1.0f, -1.0f, 0.0f},{1.0f, 1.0f}}, //右下
+	{{+1.0f, +1.0f, 0.0f},{1.0f, 0.0f}}, //右上
 	};
+
+	//Vertex vertices[] = {
+	//{{0.0f, 100.0f, 0.0f},{0.0f, 1.0f}}, //左下
+	//{{0.0f, 0.0f, 0.0f},{0.0f, 0.0f}}, //左上
+	//{{100.0f, 100.0f, 0.0f},{1.0f, 1.0f}}, //右下
+	//{{100.0f, 0.0f, 0.0f},{1.0f, 0.0f}}, //右上
+	//};
 
 	//D3D12_HEAP_PROPERTIES heapprop = {};
 	//heapprop.Type = D3D12_HEAP_TYPE_UPLOAD;
@@ -622,9 +622,9 @@ int WINAPI WinMain(HINSTANCE, HINSTANCE, LPSTR, int) {
 	XMFLOAT3 target(0, 0, 0);
 	XMFLOAT3 up(0, 1, 0);
 
-	matrix = XMMatrixLookAtLH(
+	matrix *= XMMatrixLookAtLH(
 		XMLoadFloat3(&eye), XMLoadFloat3(&target), XMLoadFloat3(&up));
-	matrix = XMMatrixPerspectiveFovLH(
+	matrix *= XMMatrixPerspectiveFovLH(
 		XM_PIDIV2, //画角は90°
 		static_cast<float>(window_width)
 		/ static_cast<float>(window_height), //アスペクト比
@@ -632,14 +632,14 @@ int WINAPI WinMain(HINSTANCE, HINSTANCE, LPSTR, int) {
 		10.0f //遠い方
 	);
 
-	matrix.r[0].m128_f32[0] = +2.0f / window_width;
-	matrix.r[1].m128_f32[1] = -2.0f / window_height;
+//	matrix.r[0].m128_f32[0] = +2.0f / window_width;
+//	matrix.r[1].m128_f32[1] = -2.0f / window_height;
 
 	//matrix.r[0].m128_f32[0] = -1.0f;
 	//matrix.r[1].m128_f32[1] = +1.0f;
 
-	matrix.r[3].m128_f32[0] = -1.0f;
-	matrix.r[3].m128_f32[1] = +1.0f;
+//	matrix.r[3].m128_f32[0] = -1.0f;
+//	matrix.r[3].m128_f32[1] = +1.0f;
 
 	ID3D12Resource* constBuff = nullptr;
 	//auto heapProp = CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD);


### PR DESCRIPTION
625行と627行に「＊」が必要でした。
今までのコードは射影行列だけしか掛かっていなかったので極端な位置に表示されていました。